### PR TITLE
add support for multi level permissions in can()

### DIFF
--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -280,8 +280,14 @@ trait Authorizable
                 }
 
                 // Check wildcard match
-                $check = substr($permission, 0, strpos($permission, '.')) . '.*';
-                if (isset($matrix[$group]) && in_array($check, $matrix[$group], true)) {
+                $checks = [];
+                $parts = explode('.', $permission);
+                for ($i = count($parts); $i > 0; $i--) {
+                    $check = implode('.', array_slice($parts, 0, $i)) . '.*';
+                    $checks[] = $check;
+                }
+
+                if (isset($matrix[$group]) && array_intersect($checks, $matrix[$group])) {
                     return true;
                 }
             }

--- a/src/Entities/Group.php
+++ b/src/Entities/Group.php
@@ -85,9 +85,17 @@ class Group extends Entity
         }
 
         // Check wildcard match
-        $check = substr($permission, 0, strpos($permission, '.')) . '.*';
+        $checks = [];
+        $parts = explode('.', $permission);
+        for ($i = count($parts); $i > 0; $i--) {
+            $check = implode('.', array_slice($parts, 0, $i)) . '.*';
+            $checks[] = $check;
+        }
 
-        return $this->permissions !== null && $this->permissions !== [] && in_array($check, $this->permissions, true);
+        return $this->permissions !== null &&
+               $this->permissions !== [] &&
+               array_intersect($checks, $this->permissions);
+
     }
 
     /**

--- a/tests/Authorization/GroupTest.php
+++ b/tests/Authorization/GroupTest.php
@@ -87,4 +87,25 @@ final class GroupTest extends TestCase
         $this->assertTrue($group2->can('users.edit'));
         $this->assertFalse($group2->can('foo.bar'));
     }
+
+    public function testCanNestedPerms(): void
+    {
+        $group = $this->groups->info('user');
+
+        $group->addPermission('foo.bar.*');
+        $group->addPermission('foo.biz.buz.*');
+
+        $this->assertTrue($group->can('foo.bar'));
+        $this->assertTrue($group->can('foo.bar.*'));
+        $this->assertTrue($group->can('foo.bar.baz'));
+        $this->assertTrue($group->can('foo.bar.buz'));
+        $this->assertFalse($group->can('foo.bar.buz.biz'));
+        $this->assertTrue($group->can('foo.biz.buz'));
+        $this->assertTrue($group->can('foo.biz.buz.*'));
+        $this->assertFalse($group->can('foo.biz'));
+        $this->assertFalse($group->can('foo.biz.*'));
+        $this->assertTrue($group->can('foo.biz.buz.bar'));
+        $this->assertFalse($group->can('foo.biz.bar.buz'));
+        $this->assertFalse($group->can('foo.biz.buz.bar.boz'));
+    }
 }


### PR DESCRIPTION
when using asterisk (*) to give user/group permissions, only one level permissions are supported by can(). This resolves #1224